### PR TITLE
Ran pycodestyle version 2.5.0 and pylint version 2.4.3 against code.

### DIFF
--- a/CyberFlood.py
+++ b/CyberFlood.py
@@ -30,7 +30,7 @@ __version__ = "1.4.3"
             # Perform Method
             cf.perform("listTests")
 
-        2. List the tests named "Matt Test":        
+        2. List the tests named "Matt Test":
             # HTTP Verb Method
             cf.get("/tests?filter[name]=Matt Test")
 
@@ -39,7 +39,7 @@ __version__ = "1.4.3"
 
         3. Change the duration of the LoadSpec for an EMix test:
             # HTTP Verb Method #1
-            cf.put("/tests/emix/" + testid, config={'loadSpecification': {'duration': 500}})           
+            cf.put("/tests/emix/" + testid, config={'loadSpecification': {'duration': 500}})
             # HTTP Verb Method #2
             cf.put("/tests/emix/" + testid, {"config": {'loadSpecification': {'duration': 600}}})
 
@@ -57,7 +57,7 @@ __version__ = "1.4.3"
 
         5. Get a Test Run Result:
             # HTTP Verb Method
-            cf.get("/test_runs/" + testrun["id"] + "/results/" + testrunresults["id"])  
+            cf.get("/test_runs/" + testrun["id"] + "/results/" + testrunresults["id"])
 
             # Perform Method
             cf.perform("getTestRunResult", testRunId=testrun["id"], testRunResultsId=testrunresults["id"])
@@ -79,7 +79,7 @@ __version__ = "1.4.3"
          explicitly specify if you want to download the OpenApi.yaml file, or just use a cached copy.
 
     1.3.0 : 06/08/2022 - Matthew Jefferson
-        -Added support for importing test cases with the "createTestImport" command. 
+        -Added support for importing test cases with the "createTestImport" command.
          Use the "upload_filename" argument for the archive.
          e.g. cf.perform("createTestImport", type="avn", upload_filename="test.zip")
 
@@ -90,7 +90,7 @@ __version__ = "1.4.3"
         -You can now specify multi-key filters with a "dash" delimiter.
          e.g. "duration-lt" translates to "filter[duration][lt]".
 
-    1.1.2 : 05/04/2021 - Matthew Jefferson    
+    1.1.2 : 05/04/2021 - Matthew Jefferson
         -Now able to download the openapi.yaml file again. Just using a new URL.
 
     1.1.1 : 07/28/2020 - Matthew Jefferson
@@ -104,7 +104,7 @@ __version__ = "1.4.3"
             1. Go to the CyberFlood GUI
             2. Click on the ? at the top-right
             3. Select "RESTful API Help"
-            4. Click on "Download OpenAPI specification: Download" and save the file in the 
+            4. Click on "Download OpenAPI specification: Download" and save the file in the
                same directory as CyberFlood.py
 
     1.0.0 : 07/16/2020 - Matthew Jefferson
@@ -116,44 +116,44 @@ __version__ = "1.4.3"
     :copyright: (c) 2020 by Matthew Jefferson.
 """
 
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-import requests
-
 import os
 import sys
 import json
 import re
 import logging
 import datetime
-
 # Required for processing error messages from the ReST API.
 import ast
-
-#import inspect
+#  import inspect
 import functools
-
 # Copy is require for the deepcopy function.
 import copy
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+import requests
+
 
 # pickle and yaml are required for processing the OpenAPI yaml file.
-#import pickle
-#import pylibyaml
+#  import pickle
+#  import pylibyaml
 import yaml
 
-#==============================================================================
+
+# =============================================================================
 def logging_decorator(func):
     """This decorator is used to populate the logs with the Python client commands as they are executed.
     """
     @functools.wraps(func)
     def wrapper_decorator(*args, **kwargs):
-        logging.debug("ENTER=" + str(func) + " args=" + str(args) + " kwargs=" + str(kwargs))        
+        logging.debug("ENTER=%s args=%s kwargs=%s", str(func), str(args),
+                      str(kwargs))
 
         value = func(*args, **kwargs)
 
-        logging.debug("LEAVE=" + str(func) + " returns=" + str(value))
+        logging.debug("LEAVE=%s returns=%s", str(func), str(value))
 
         return value
-    return wrapper_decorator 
+    return wrapper_decorator
+
 
 # Copyright Ferry Boender, released under the MIT license.
 def deepupdate(target, src):
@@ -170,26 +170,27 @@ def deepupdate(target, src):
     {'name': 'Ferry', 'hobbies': ['programming', 'sci-fi', 'gaming']}
     """
     for k, v in src.items():
-        if type(v) == list:
-            if not k in target:
+        if isinstance(v, list):
+            if k not in target:
                 target[k] = copy.deepcopy(v)
             else:
                 target[k].extend(v)
-        elif type(v) == dict:
-            if not k in target:
+        elif isinstance(v, dict):
+            if k not in target:
                 target[k] = copy.deepcopy(v)
             else:
                 deepupdate(target[k], v)
-        elif type(v) == set:
-            if not k in target:
+        elif isinstance(v, set):
+            if k not in target:
                 target[k] = v.copy()
             else:
                 target[k].update(v.copy())
         else:
             target[k] = copy.copy(v)
 
-#==============================================================================
-class CyberFlood:    
+
+# =============================================================================
+class CyberFlood:
     def __init__(self, username, password, controller_address, perform_commands=True, use_yaml_cache=True, log_level="INFO", log_path=None):
 
         requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
@@ -209,10 +210,10 @@ class CyberFlood:
         self.object_types = {}
 
         self.__bearerToken = None
-        #self.__isLogged = False
+        #  self.__isLogged = False
         self.__session = requests.session()
         self.__session.verify = False
-    
+
         defaultlogpath = os.path.join(os.getcwd(), "logs")
 
         now = datetime.datetime.now()
@@ -221,7 +222,7 @@ class CyberFlood:
         tempdir += str(os.getpid())
         defaultlogpath = os.path.join(defaultlogpath, tempdir)
         defaultlogpath = os.path.expanduser(defaultlogpath)
-        
+
         # The STC_LOG_OUTPUT_DIRECTORY will override the default path.
         self.log_path = os.getenv("CF_LOG_OUTPUT_DIRECTORY", defaultlogpath)
 
@@ -230,7 +231,7 @@ class CyberFlood:
             self.log_path = log_path
 
         self.log_path = os.path.abspath(self.log_path)
-        self.log_file = os.path.join(self.log_path, "cf_restapi.log")        
+        self.log_file = os.path.join(self.log_path, "cf_restapi.log")
 
         if not os.path.exists(self.log_path):
             os.makedirs(self.log_path)
@@ -248,8 +249,8 @@ class CyberFlood:
 
         logging.basicConfig(filename=self.log_file, filemode="w", level=self.log_level, format="%(asctime)s %(message)s")
 
-        # The logger is now ready.        
-        logging.info("Executing __init__: " + str(arguments))
+        # The logger is now ready.
+        logging.info("Executing __init__: %s", str(arguments))
 
         requests_log = logging.getLogger("requests.packages.urllib3")
         requests_log.propagate = True
@@ -263,15 +264,12 @@ class CyberFlood:
         else:
             errmsg = "Authorization failed. Please check user credentials."
             logging.error(errmsg)
-            raise Exception(errmsg)              
+            raise Exception(errmsg)
 
         if self.perform_commands:
-            # Perform Commands are enabled. We need to download the OpenAPI.yaml file and 
+            # Perform Commands are enabled. We need to download the OpenAPI.yaml file and
             # generate the class objects for each command.
             self._enable_perform_commands(use_cached_commands=use_yaml_cache)
-
-
-        return    
 
     @logging_decorator
     def post(self, url, *args, **kwargs):
@@ -281,10 +279,10 @@ class CyberFlood:
     @logging_decorator
     def delete(self, url, *args, **kwargs):
         result = self.exec("delete", url, *args, **kwargs)
-        return 
+        return result
 
     @logging_decorator
-    def put(self, url, *args, **kwargs):              
+    def put(self, url, *args, **kwargs):
         result = self.exec("put", url, *args, **kwargs)
         return result
 
@@ -294,50 +292,50 @@ class CyberFlood:
         return result
 
     @logging_decorator
-    def perform(self, command_name, *args, command_type=None, **kwargs):         
+    def perform(self, command_name, *args, command_type=None, **kwargs):
         """This method is used to execute "Perform Commands". These are the commands that are listed
         in the CyberFlood API documentation. This method uses the CfCommand objects.
         e.g.
             getEmixTest
             listTests
             listTestRunResults
-        """       
+        """
         if not self.perform_commands:
-            raise Exception("Perform Commands are not enabled. Use the perform_commands=True argument when initializing the CyberFlood client.")        
+            raise Exception("Perform Commands are not enabled. Use the perform_commands=True argument when initializing the CyberFlood client.")
 
         # Determine which command is being invoked.
         if command_name not in self.commands.keys():
-            raise Exception("The command '" + command_name + "' is not valid.")        
+            raise Exception("The command '" + command_name + "' is not valid.")
 
         command_list = list(self.commands[command_name].keys())
 
         if len(command_list) > 1:
             # There is more than one command with this command_name. The user must specify the command_type.
             if not command_type:
-                raise Exception("You must specify the type for this command.")                    
-        else:            
+                raise Exception("You must specify the type for this command.")
+        else:
             command_type = command_list[0]
 
         command = self.commands[command_name][command_type]
 
-        result = command.perform(*args, **kwargs)            
+        result = command.perform(*args, **kwargs)
 
-        return result    
+        return result
 
-    def exec(self, httpverb, url, *args, filters=None, upload_filename=None, **kwargs):  
-        """Send the specified HTTP request to the CyberFlood ReST API.    
-        The filter argument is special. It is a dictionary of filters that must be added to the URL.  
+    def exec(self, httpverb, url, *args, filters=None, upload_filename=None, **kwargs):
+        """Send the specified HTTP request to the CyberFlood ReST API.
+        The filter argument is special. It is a dictionary of filters that must be added to the URL.
 
         Use the "upload_filename" argument to upload files to the server.
         """
 
         # Construct the complete URL.
         url = self.controller_address + url
-        url += self._add_filters(filters)        
+        url += self._add_filters(filters)
 
         # Construct the json_payload, which can be a combination of args and kwargs.
         payload = {}
-        json_payload = {}        
+        json_payload = {}
 
         if args:
             # Only one positional arg is supported, and it must be a dictionary.
@@ -349,19 +347,19 @@ class CyberFlood:
         if len(list(payload.keys())) > 0:
             json_payload = json.dumps(payload)
 
-        httpverb = httpverb.lower() 
+        httpverb = httpverb.lower()
 
-        if upload_filename: 
+        if upload_filename:
             filedata = open(upload_filename, "rb")
             filejson = {"file": filedata}
             response = self.__session.post(url, files=filejson, data=payload, verify=False)
 
         elif httpverb == "get":
             response = self.__session.get(url, data=json_payload, headers={'Content-Type': 'application/json'}, verify=False)
-        elif httpverb == "post":            
+        elif httpverb == "post":
             response = self.__session.post(url, data=json_payload, headers={'Content-Type': 'application/json'}, verify=False)
         elif httpverb == "put":
-            response = self.__session.put(url, data=json_payload, headers={'Content-Type': 'application/json'}, verify=False)            
+            response = self.__session.put(url, data=json_payload, headers={'Content-Type': 'application/json'}, verify=False)
         elif httpverb == "delete":
             response = self.__session.delete(url)
         else:
@@ -369,7 +367,7 @@ class CyberFlood:
 
         if not response.ok:
             self._process_error(response)
-        
+
         return_value = None
 
         # print("HERE")
@@ -398,7 +396,7 @@ class CyberFlood:
         elif content_disposition and re.match("attachment", content_disposition, flags=re.I):
             # The response contained an attachment.
             # The content-disposition will look something like this: attachment; filename="event.log"
-            match = re.search("filename=\"(.+)\"", content_disposition, flags=re.I)            
+            match = re.search("filename=\"(.+)\"", content_disposition, flags=re.I)
             filename = match.group(1)
             return_value = self._save_file(response, filename)
         elif response.headers.get("content-type") == "application/octet-stream":
@@ -409,16 +407,16 @@ class CyberFlood:
                 filename = url.rsplit('/', 1)[1]
             else:
                 filename = "unknown_file"
-            
+
             return_value = self._save_file(response, filename)
         else:
             # Whoops...looks like we got a response that wasn't anticipated.
             logging.debug(str(response.headers.get))
             raise Exception("ERROR: Unknown response type (" + str(response.headers.get("content-type")) + ").")
 
-        return return_value 
+        return return_value
 
-    def _save_file(self, response, filename, directory=None):        
+    def _save_file(self, response, filename, directory=None):
         """ Save a file attachment from a response to the current directory (or possibly a subdirectory).
         """
 
@@ -429,9 +427,8 @@ class CyberFlood:
         path = os.path.dirname(filename)
 
         if not os.path.exists(path):
-            os.makedirs(path) 
+            os.makedirs(path)
 
-        file_size_dl = 0
         try:
             with open(filename, 'wb') as f:
                 for buff in response.iter_content(chunk_size=16384):
@@ -441,17 +438,17 @@ class CyberFlood:
         finally:
             response.close()
 
-        return filename         
+        return filename
 
-    def _add_filters(self, filters):      
+    def _add_filters(self, filters):
         """Convert any filters, specified as a dictionary by the user, into a string for a URL.
-        """  
+        """
         filtersurl = ""
-        if filters:   
+        if filters:
             # The user may specify a multi-key filter with a "dash" delimiter.
             # e.g. duration-lt translates to filter[duration][lt].
 
-            for key in filters.keys():                
+            for key in filters.keys():
                 if filtersurl != "":
                     filtersurl += "&"
 
@@ -459,7 +456,7 @@ class CyberFlood:
                 for subfilter in key.split("-"):
                     filtersurl += "[" + subfilter + "]"
 
-                #value = requests.utils.quote(filters[key])
+                #  value = requests.utils.quote(filters[key])
                 value = filters[key]
                 filtersurl += "=" + str(value)
 
@@ -477,21 +474,21 @@ class CyberFlood:
             #  "message":"Validation failed, config subnets client vlans id must be an integer",
             #  "errors":{"config":{"subnets":{"client":{"1":{"vlans":{"0":{"id":["must be an integer","must be greater than or equal to 0","must be less than or equal to 4094"]}}}}}}}}
             errordetails = ast.literal_eval(response.text)
-            errmsg = errordetails.get("message", "No message")        
+            errmsg = errordetails.get("message", "No message")
 
             additionaldetails = errordetails.get("errors", None)
             if additionaldetails:
                 errmsg += "\n" + str(additionaldetails)
         else:
             errmsg = "An unspecified error occurred (" + str(response.status_code) + ")"
-        
+
         logging.error(errmsg)
-        raise Exception(errmsg)     
+        raise Exception(errmsg)
 
     def _enable_perform_commands(self, use_cached_commands):
         """Generate CyberFlood "Perform" command classes, based on the OpenAPI.yaml spec.
-           There is an option to use the "cached" version of these commands, because parsing the YAML 
-           file is pretty slow. 
+           There is an option to use the "cached" version of these commands, because parsing the YAML
+           file is pretty slow.
            When caching is enabled, the dictionary that is generated from the OpenAPI.yaml file is saved
            to disk as a JSON file.
         """
@@ -499,74 +496,71 @@ class CyberFlood:
         path = os.path.dirname(__file__)
         path = os.path.abspath(path)
 
-        # Only use the cached commands if they match CyberFlood controller version.    
-        controller = self.get("/system/version")            
-        # "version": "22.4.1030"                                                
+        # Only use the cached commands if they match CyberFlood controller version.
+        controller = self.get("/system/version")
+        # "version": "22.4.1030"
 
         cached_commands_filename = os.path.join(path, "perform_commands_cache_" + controller["version"] + ".json")
         cached_commands_filename = os.path.abspath(cached_commands_filename)
 
         api_spec = None
-        if use_cached_commands:                           
+        if use_cached_commands:
             logging.info("Attempting to use the cached OpenAPI.yaml file....")
 
-            if os.path.isfile(cached_commands_filename):            
+            if os.path.isfile(cached_commands_filename):
                 # Okay, the file exists, so load the cached api_spec dictionary.
                 with open(cached_commands_filename) as f:
                     api_spec = json.load(f)
             else:
                 # The cached commands were not found. This means we'll need to attempt to download the OpenAPI.yaml file.
                 errmsg = "Unable to locate the cached commands file: " + cached_commands_filename
-                logging.warn(errmsg)                    
+                logging.warning(errmsg)
 
         if not api_spec:
             # Download the OpenAPI.yaml file.
             try:
                 # Download the ReST API specification for the controller.
-                #specfilename = self.get("/documentation/openapi.yaml")        
-                spec_filename = self.get("/client/openapi.yaml")                             
+                # specfilename = self.get("/documentation/openapi.yaml")
+                spec_filename = self.get("/client/openapi.yaml")
 
             except Exception as e:
                 raise Exception("Unable to download the OpenAPI.yaml file from the controller. This file is required for 'perform' commands.\n" + str(e))
-        
-            if os.path.isfile(spec_filename):            
-                #print("DEBUG ONLY!!!!!!")                   
-                #print("Start=", datetime.datetime.now().strftime("%H:%M:%S"))
+
+            if os.path.isfile(spec_filename):
+                # print("DEBUG ONLY!!!!!!")
+                # print("Start=", datetime.datetime.now().strftime("%H:%M:%S"))
                 api_spec = self._convert_yaml_to_dict(spec_filename)
-                #print("Generate=", datetime.datetime.now().strftime("%H:%M:%S"))
+                # print("Generate=", datetime.datetime.now().strftime("%H:%M:%S"))
 
                 if use_cached_commands:
-                    # NOTE: I'm a bit torn here. I could always save the cached commands to disk, but that might be 
+                    # NOTE: I'm a bit torn here. I could always save the cached commands to disk, but that might be
                     #       a problem for logistics. Instead, I'm only saving it to disk if the user is using cached commands.
                     with open(cached_commands_filename, 'w') as f:
                         json.dump(api_spec, f)
             else:
-                errmsg = "Unable to locate the OpenAPI.yaml file " + specfilename + ". This file is required for 'perform' commands."
+                errmsg = "Unable to locate the OpenAPI.yaml file " + spec_filename + ". This file is required for 'perform' commands."
                 logging.error(errmsg)
-                raise Exception(errmsg)              
+                raise Exception(errmsg)
 
         if api_spec:
-            self._generate_classes(api_spec)   
+            self._generate_classes(api_spec)
         else:
             errmsg = "Unable to obtain the CyberFlood API specification. Try disabling perform_commands."
             logging.error(errmsg)
-            raise Exception(errmsg)  
-        
-        return
+            raise Exception(errmsg)
 
-
-    def _convert_yaml_to_dict(self, inputfilename):        
+    def _convert_yaml_to_dict(self, inputfilename):
         """Open and convert the OpenAPI.yaml file to a Python dictionary.
         """
         yamldict = {}
 
         try:
             with open(inputfilename, "r", encoding="utf-8") as yaml_file:
-                # The load() method has be depricated.
-                #yamldict = load(yaml_file, Loader=Loader)                
-                
-                # NOTE: If you are unsatified with the speed of this method, consider using the LibYAML parser instead.
-                #       The code here doesn't change. You just need to import the LibYAML parser instead. 
+                # The load() method has be deprecated.
+                # yamldict = load(yaml_file, Loader=Loader)
+
+                # NOTE: If you are unsatisfied with the speed of this method, consider using the LibYAML parser instead.
+                #       The code here doesn't change. You just need to import the LibYAML parser instead.
                 #       The trick is that you'll likely need to download and build from source. I don't think pip will work.
                 #       https://pypi.org/project/pylibyaml/
                 yamldict = yaml.safe_load(yaml_file)
@@ -574,7 +568,7 @@ class CyberFlood:
         except yaml.YAMLError as exc:
             if hasattr(exc, 'problem_mark'):
                 mark = exc.problem_mark
-                print("Error position: (%s:%s)" % (mark.line+1, mark.column+1))
+                print("Error position: (%s:%s)" % (mark.line + 1, mark.column + 1))
             else:
                 errmsg = "Unexpected error while parsing the YAML:", sys.exc_info()[1]
                 logging.error(errmsg)
@@ -584,7 +578,7 @@ class CyberFlood:
 
     def _generate_classes(self, api_spec):
         """The method instantiates the perform commands, based on the OpenAPI.yaml file from the controller.
-        """        
+        """
         self.commands = {}
 
         # Keep track of the commands available for each object type.
@@ -602,7 +596,7 @@ class CyberFlood:
         self.object_types = {}
 
         for path in api_spec["paths"].keys():
-            for verb in api_spec["paths"][path].keys():                
+            for verb in api_spec["paths"][path].keys():
                 command = CfCommand(self, path, verb, api_spec["paths"][path][verb])
 
                 # Some command names are used by more than one object type (key).
@@ -613,13 +607,12 @@ class CyberFlood:
 
                 if command.tag not in self.object_types:
                     self.object_types[command.tag] = {}
-                
+
                 self.object_types[command.tag][command.name] = command
 
-        return         
 
-#==============================================================================
-class CfCommand:    
+# =============================================================================
+class CfCommand:
     """This class defines each of the perform commands for CyberFlood.
     A perform command is an command that is used with the perform method.
     e.g.
@@ -639,11 +632,11 @@ class CfCommand:
         # The "tags" differentiate the various commands with the same name:
         # e.g. There is a "reboot" command for the "System" and "Devices".
         #      /system/reboot
-        #      /devices/{deviceId}/reboot        
+        #      /devices/{deviceId}/reboot
         self.tag = definition["tags"][0]
 
         self.name = definition["operationId"]
-        
+
         self.path_parameters = []
         self.query_parameters = []
         self.header_parameters = []
@@ -657,26 +650,24 @@ class CfCommand:
             else:
                 print("Unknown parameter in=" + parameter["in"])
 
-        return
-
     @logging_decorator
     def perform(self, *args, **kwargs):
-        # Generate the resolvedpath by replacing the path argument names with 
+        # Generate the resolvedpath by replacing the path argument names with
         # the user-specified values for each argument.
         # All arguments found in the path are required.
         # e.g. path = '/tests/{testId}/results/{testResultId}'
-        #     returns = '/tests/lkj43lkjfi34flklksflkji43jlfrl2/results/b5fb4a9e322c4333805aa9e13c433f85'                
+        #     returns = '/tests/lkj43lkjfi34flklksflkji43jlfrl2/results/b5fb4a9e322c4333805aa9e13c433f85'
         resolvedpath = self.path
         for arg in re.findall("{.+?}", self.path):
             # remove the brackets for the arg to find the dictionary key.
             key = re.sub("[{}]", "", arg)
             if key not in kwargs.keys():
-                raise Exception("The argument '" + key + "' is required for the command " + self.name + " (" + self.tag + ").")        
-        
-            resolvedpath = re.sub(arg, kwargs[key], resolvedpath)  
-            
-            #Remove this key, so that it doesn't get added to the HTTP payload.      
-            kwargs.pop(key)            
+                raise Exception("The argument '" + key + "' is required for the command " + self.name + " (" + self.tag + ").")
+
+            resolvedpath = re.sub(arg, kwargs[key], resolvedpath)
+
+            # Remove this key, so that it doesn't get added to the HTTP payload.
+            kwargs.pop(key)
 
         result = self.cf.exec(self.httpverb, resolvedpath, *args, **kwargs)
 


### PR DESCRIPTION
Mostly removed unnecessary spaces but did find a few errors which were: using an undefined variable spec_filename, switched to lazy logging, missed return value and replaced calling deprecated warn with supported warning. Also removed unused parameter.